### PR TITLE
fix: hydration error on stackblitz

### DIFF
--- a/app.vue
+++ b/app.vue
@@ -41,9 +41,9 @@ const {data, error, pending, execute, status} = await useLazyFetch<{ rows: RowIn
 const rows: Ref<RowInterface[]> = computed(() => data.value?.rows || [])
 
 const stackblitz = ref(false)
-if(process.client) {
+onMounted(() => {
     stackblitz.value = window.location.href.includes('webcontainer')
-}
+})
 </script>
 <style scoped>
 main {


### PR DESCRIPTION
This PR fixes a hydration error when actually running on stackblitz. Generally, `onMounted` is preferred over `process.client` unless you have a good reason to use it (e.g. importing packages only on the client-side)